### PR TITLE
Adding the Ability to Register a DeviceToken with the UA site

### DIFF
--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -7,48 +7,53 @@ using UrbanAirSharp.Type;
 
 namespace TestApp
 {
-	class Program
-	{
-		private const String AppKey = "WruqqOeaTlSKSRCUJrzA0g";
-		private const String AppMasterSecret = "GcXgFOl5QSKgMfeYZWPb_w";
+    class Program
+    {
+        private const String AppKey = "WruqqOeaTlSKSRCUJrzA0g";
+        private const String AppMasterSecret = "GcXgFOl5QSKgMfeYZWPb_w";
 
-		static void Main(String[] args)
-		{
-			var client = new UrbanAirSharpGateway(AppKey, AppMasterSecret);
 
-			client.Validate("Validate push", new List<DeviceType>() { DeviceType.Android }, "946fdc3d-0284-468f-a2f7-d007ed694907");
+        static void Main(String[] args)
+        {
+            var client = new UrbanAirSharpGateway(AppKey, AppMasterSecret);
 
-			client.Push("Broadcast Alert");
+            client.Validate("Validate push", new List<DeviceType>() { DeviceType.Android }, "946fdc3d-0284-468f-a2f7-d007ed694907");
 
-			client.Push("Broadcast Alert to Androids", new List<DeviceType>() { DeviceType.Android });
+            client.Push("Broadcast Alert");
 
-			client.Push("Targeted Alert to device", new List<DeviceType>() { DeviceType.Android }, "946fdc3d-0284-468f-a2f7-d007ed694907");
-			
-			client.Push("Custom Alert per device type", null, null, new List<BaseAlert>()
-			{
-				new AndroidAlert()
-				{
-					Alert = "Custom Android Alert",
-					CollapseKey = "Collapse_Key",
-					DelayWhileIdle = true,
-					GcmTimeToLive = 5
-				}
-			});
+            client.Push("Broadcast Alert to Androids", new List<DeviceType>() { DeviceType.Android });
 
-			//these are just examples of tags
-			var rugbyFanAudience = new Audience(AudienceType.Tag, "Rugby Fan");
-			var footballFanAudience = new Audience(AudienceType.Tag, "Football Fan");
-			var notFootballFanAudience = new Audience().NotAudience(footballFanAudience);
-			var newZealandAudience = new Audience(AudienceType.Alias, "NZ");
-			var englishAudience = new Audience(AudienceType.Tag, "language_en");
+            client.Push("Targeted Alert to device", new List<DeviceType>() { DeviceType.Android }, "946fdc3d-0284-468f-a2f7-d007ed694907");
 
-			var fansAudience = new Audience().OrAudience(new List<Audience>() { rugbyFanAudience, notFootballFanAudience });
+            client.Push("Custom Alert per device type", null, null, new List<BaseAlert>()
+            {
+                new AndroidAlert()
+                {
+                    Alert = "Custom Android Alert",
+                    CollapseKey = "Collapse_Key",
+                    DelayWhileIdle = true,
+                    GcmTimeToLive = 5
+                }
+            });
 
-			var customAudience = new Audience().AndAudience(new List<Audience>() { fansAudience, newZealandAudience, englishAudience });
+            //these are just examples of tags
+            var rugbyFanAudience = new Audience(AudienceType.Tag, "Rugby Fan");
+            var footballFanAudience = new Audience(AudienceType.Tag, "Football Fan");
+            var notFootballFanAudience = new Audience().NotAudience(footballFanAudience);
+            var newZealandAudience = new Audience(AudienceType.Alias, "NZ");
+            var englishAudience = new Audience(AudienceType.Tag, "language_en");
 
-			client.Push("English speaking New Zealand Rugby fans", null, null, null, customAudience);
+            var fansAudience = new Audience().OrAudience(new List<Audience>() { rugbyFanAudience, notFootballFanAudience });
 
-			Console.ReadLine();
-		}
-	}
+            var customAudience = new Audience().AndAudience(new List<Audience>() { fansAudience, newZealandAudience, englishAudience });
+
+            client.Push("English speaking New Zealand Rugby fans", null, null, null, customAudience);
+
+
+            var result = client.RegisterDeviceToken("");
+            Console.WriteLine("Register Device Response: Ok?: {0}   Message: {1}    ErrorCode: {2}  ErrorMessage: {3}", result.Ok, result.Message, result.ErrorCode, result.Error);
+
+            Console.ReadLine();
+        }
+    }
 }

--- a/src/UrbanAirSharp/Dto/DeviceToken.cs
+++ b/src/UrbanAirSharp/Dto/DeviceToken.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace UrbanAirSharp.Dto
+{
+    public class DeviceToken
+    {
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        [JsonProperty("tags")]
+        public string[] Tags { get; set; }
+
+        [JsonProperty("badge")]
+        public int Badge { get; set; }
+
+        [JsonProperty("quiettime")]
+        public QuietTime QuietTime { get; set; }
+
+        [JsonProperty("tz")]
+        public string Timezone { get; set; }
+
+        [JsonIgnore]
+        public string Token { get; set; }
+    }
+
+    public class QuietTime
+    {
+        [JsonProperty("start")]
+        public string Start { get; set; }
+
+        [JsonProperty("end")]
+        public string End { get; set; }
+    }
+}

--- a/src/UrbanAirSharp/Request/Base/PutRequest.cs
+++ b/src/UrbanAirSharp/Request/Base/PutRequest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using UrbanAirSharp.Response;
+
+namespace UrbanAirSharp.Request.Base
+{
+    public class PutRequest<T> : BaseRequest
+    {
+        public readonly Encoding Encoding = Encoding.UTF8;
+        public const String MediaType = "application/json";
+
+        protected T Content;
+
+
+        public PutRequest(T content) : base(ServiceModelConfig.Host, ServiceModelConfig.HttpClient, ServiceModelConfig.SerializerSettings)
+        {
+            Content = content;
+        }
+
+        public override async Task<BaseResponse> ExecuteAsync()
+        {
+            Log.Debug(RequestMethod + " - " + Host + RequestUrl);
+
+            var json = JsonConvert.SerializeObject(Content, SerializerSettings);
+
+            Log.Debug("Payload - " + json);
+
+            var response = await HttpClient.PutAsync(Host + RequestUrl, new StringContent(json, Encoding, MediaType));
+
+            return await DeserializeResponseAsync(response);
+        }
+    }
+}

--- a/src/UrbanAirSharp/Request/DeviceTokenRequest.cs
+++ b/src/UrbanAirSharp/Request/DeviceTokenRequest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UrbanAirSharp.Dto;
+using UrbanAirSharp.Request.Base;
+
+namespace UrbanAirSharp.Request
+{
+    /// <summary>
+    /// Allows you to Register a new Device Token with Urbanairship
+    /// </summary>
+    /// <see cref="http://docs.urbanairship.com/reference/api/v3/registration.html"/>
+    public class DeviceTokenRequest : PutRequest<DeviceToken>
+    {
+        public DeviceTokenRequest(DeviceToken device) : base(device)
+        {
+            if (string.IsNullOrEmpty(device.Token))
+                throw new ArgumentException("The device tokens Token field is required", "device");
+
+            RequestUrl = string.Format("/api/device_tokens/{0}", device.Token);
+        }
+    }
+}

--- a/src/UrbanAirSharp/UrbanAirSharp.csproj
+++ b/src/UrbanAirSharp/UrbanAirSharp.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Dto\BaseAlert.cs" />
+    <Compile Include="Dto\DeviceToken.cs" />
     <Compile Include="Dto\OpenAction.cs" />
     <Compile Include="Dto\AndroidAlert.cs" />
     <Compile Include="Dto\Audience.cs" />
@@ -67,6 +68,8 @@
     <Compile Include="Request\Base\DeleteRequest.cs" />
     <Compile Include="Request\Base\GetRequest.cs" />
     <Compile Include="Request\Base\PostRequest.cs" />
+    <Compile Include="Request\Base\PutRequest.cs" />
+    <Compile Include="Request\DeviceTokenRequest.cs" />
     <Compile Include="Request\ScheduleDeleteRequest.cs" />
     <Compile Include="Request\ScheduleGetRequest.cs" />
     <Compile Include="Request\ScheduleListRequest.cs" />

--- a/src/UrbanAirSharp/UrbanAirSharpGateway.cs
+++ b/src/UrbanAirSharp/UrbanAirSharpGateway.cs
@@ -19,170 +19,181 @@ using UrbanAirSharp.Type;
 
 namespace UrbanAirSharp
 {
-	/// <summary>
-	/// A gateway for pushing notifications to the Urban Airship API V3
-	/// http://docs.urbanairship.com/reference/api/v3/
-	/// 
-	/// Supported:
-	/// ---------
-	/// api/push
-	/// api/push/validate
-	/// api/schedule 
-	/// 
-	/// Not Supported Yet:
-	/// -----------------
-	/// api/tags 
-	/// api/feeds 
-	/// api/reports 
-	/// api/device_tokens 
-	/// api/segments 
-	/// api/location 
-	/// </summary>
+    /// <summary>
+    /// A gateway for pushing notifications to the Urban Airship API V3
+    /// http://docs.urbanairship.com/reference/api/v3/
+    /// 
+    /// Supported:
+    /// ---------
+    /// api/push
+    /// api/push/validate
+    /// api/schedule 
+    /// 
+    /// Not Supported Yet:
+    /// -----------------
+    /// api/tags 
+    /// api/feeds 
+    /// api/reports 
+    /// api/device_tokens 
+    /// api/segments 
+    /// api/location 
+    /// </summary>
 
-	public class UrbanAirSharpGateway
-	{
-		private static readonly ILog Log = LogManager.GetLogger(typeof(UrbanAirSharpGateway));
+    public class UrbanAirSharpGateway
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(UrbanAirSharpGateway));
 
-		public UrbanAirSharpGateway(String appKey, String appMasterSecret)
-		{
-			XmlConfigurator.Configure();
-			ServiceModelConfig.Create(appKey, appMasterSecret);
-		}
+        public UrbanAirSharpGateway(String appKey, String appMasterSecret)
+        {
+            XmlConfigurator.Configure();
+            ServiceModelConfig.Create(appKey, appMasterSecret);
+        }
 
-		/// <summary>
-		/// - Broadcast to all devices
-		/// - Broadcast to one device type
-		/// - Send to a targeted device
-		/// - Broadcast to all devices with a different alert for each type
-		/// </summary>
-		/// <param name="alert">The message to be pushed</param>
-		/// <param name="deviceTypes">use null for broadcast</param>
-		/// <param name="deviceId">use null for broadcast or deviceTypes must contain 1 element that distinguishes this deviceId</param>
-		/// <param name="deviceAlerts">per device alert messages and extras</param>
-		/// <param name="customAudience">a more specific way to choose the audience for the push. If this is set, deviceId is ignored</param>
-		/// <returns></returns>
-		public BaseResponse Push(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null, IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
-		{
-			var request = new PushRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience));
-			
-			var response = request.ExecuteAsync();
+        /// <summary>
+        /// - Broadcast to all devices
+        /// - Broadcast to one device type
+        /// - Send to a targeted device
+        /// - Broadcast to all devices with a different alert for each type
+        /// </summary>
+        /// <param name="alert">The message to be pushed</param>
+        /// <param name="deviceTypes">use null for broadcast</param>
+        /// <param name="deviceId">use null for broadcast or deviceTypes must contain 1 element that distinguishes this deviceId</param>
+        /// <param name="deviceAlerts">per device alert messages and extras</param>
+        /// <param name="customAudience">a more specific way to choose the audience for the push. If this is set, deviceId is ignored</param>
+        /// <returns></returns>
+        public BaseResponse Push(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null, IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
+        {
+            var request = new PushRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience));
+            
+            var response = request.ExecuteAsync();
 
-			return response.Result;
-		}
+            return response.Result;
+        }
 
-		/// <summary>
-		/// Validates a push request. Duplicates Push without actually sending the alert. See Push
-		/// </summary>
-		/// <param name="alert">The message to be pushed</param>
-		/// <param name="deviceTypes">use null for broadcast</param>
-		/// <param name="deviceId">use null for broadcast or deviceTypes must contain 1 element that distinguishes this deviceId</param>
-		/// <param name="deviceAlerts">per device alert messages and extras</param>
-		/// <param name="customAudience">a more specific way to choose the audience for the push. If this is set, deviceId is ignored</param>
-		/// <returns></returns>
-		public BaseResponse Validate(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null,
-			IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
-		{
-			var request = new PushValidateRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience));
+        /// <summary>
+        /// Validates a push request. Duplicates Push without actually sending the alert. See Push
+        /// </summary>
+        /// <param name="alert">The message to be pushed</param>
+        /// <param name="deviceTypes">use null for broadcast</param>
+        /// <param name="deviceId">use null for broadcast or deviceTypes must contain 1 element that distinguishes this deviceId</param>
+        /// <param name="deviceAlerts">per device alert messages and extras</param>
+        /// <param name="customAudience">a more specific way to choose the audience for the push. If this is set, deviceId is ignored</param>
+        /// <returns></returns>
+        public BaseResponse Validate(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null,
+            IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
+        {
+            var request = new PushValidateRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience));
 
-			var response = request.ExecuteAsync();
+            var response = request.ExecuteAsync();
 
-			return response.Result;
-		}
+            return response.Result;
+        }
 
-		public BaseResponse ScheduleAdd(String alert, DateTime triggerDate)
-		{
-			//TODO:
-			return null;
-		}
+        public BaseResponse ScheduleAdd(String alert, DateTime triggerDate)
+        {
+            //TODO:
+            return null;
+        }
 
-		public BaseResponse ScheduleEdit(Guid scheduleId, String alert, DateTime triggerDate)
-		{
-			//TODO:
-			return null;
-		}
+        public BaseResponse ScheduleEdit(Guid scheduleId, String alert, DateTime triggerDate)
+        {
+            //TODO:
+            return null;
+        }
 
-		public BaseResponse ScheduleDelete(Guid scheduleId)
-		{
-			//TODO:
-			return null;
-		}
+        public BaseResponse ScheduleDelete(Guid scheduleId)
+        {
+            //TODO:
+            return null;
+        }
 
-		public BaseResponse ScheduleGet(Guid scheduleId)
-		{
-			//TODO:
-			return null;
-		}
+        public BaseResponse ScheduleGet(Guid scheduleId)
+        {
+            //TODO:
+            return null;
+        }
 
-		public BaseResponse SchedulesList()
-		{
-			//TODO:
-			return null;
-		}
+        public BaseResponse SchedulesList()
+        {
+            //TODO:
+            return null;
+        }
 
-		private static Push CreatePush(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null, IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
-		{
-			var push = new Push()
-			{
-				Notification = new Notification()
-				{
-					DefaultAlert = alert
-				}
-			};
+        private static Push CreatePush(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null, IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
+        {
+            var push = new Push()
+            {
+                Notification = new Notification()
+                {
+                    DefaultAlert = alert
+                }
+            };
 
-			if (customAudience != null)
-			{
-				deviceId = null;
+            if (customAudience != null)
+            {
+                deviceId = null;
 
-				push.Audience = customAudience;
-			}
+                push.Audience = customAudience;
+            }
 
-			if (deviceTypes != null)
-			{
-				push.DeviceTypes = deviceTypes;
+            if (deviceTypes != null)
+            {
+                push.DeviceTypes = deviceTypes;
 
-				if (deviceId != null)
-				{
-					if (deviceTypes.Count != 1)
-					{
-						throw new InvalidOperationException("when deviceId is not null, deviceTypes must contain 1 element which identifies the deviceId type");
-					}
+                if (deviceId != null)
+                {
+                    if (deviceTypes.Count != 1)
+                    {
+                        throw new InvalidOperationException("when deviceId is not null, deviceTypes must contain 1 element which identifies the deviceId type");
+                    }
 
-					var deviceType = deviceTypes[0];
+                    var deviceType = deviceTypes[0];
 
-					switch (deviceType)
-					{
-						case DeviceType.Android:
-							push.SetAudience(AudienceType.Android, deviceId);
-							break;
-						case DeviceType.Ios:
-							push.SetAudience(AudienceType.Ios, deviceId);
-							break;
-						case DeviceType.Wns:
-							push.SetAudience(AudienceType.Windows, deviceId);
-							break;
-						case DeviceType.Mpns:
-							push.SetAudience(AudienceType.WindowsPhone, deviceId);
-							break;
-						case DeviceType.Blackberry:
-							push.SetAudience(AudienceType.Blackberry, deviceId);
-							break;
-					}
-				}
-			}
+                    switch (deviceType)
+                    {
+                        case DeviceType.Android:
+                            push.SetAudience(AudienceType.Android, deviceId);
+                            break;
+                        case DeviceType.Ios:
+                            push.SetAudience(AudienceType.Ios, deviceId);
+                            break;
+                        case DeviceType.Wns:
+                            push.SetAudience(AudienceType.Windows, deviceId);
+                            break;
+                        case DeviceType.Mpns:
+                            push.SetAudience(AudienceType.WindowsPhone, deviceId);
+                            break;
+                        case DeviceType.Blackberry:
+                            push.SetAudience(AudienceType.Blackberry, deviceId);
+                            break;
+                    }
+                }
+            }
 
-			if (deviceAlerts == null || deviceAlerts.Count <= 0)
-			{
-				return push;
-			}
+            if (deviceAlerts == null || deviceAlerts.Count <= 0)
+            {
+                return push;
+            }
 
-			push.Notification.AndroidAlert = (AndroidAlert)deviceAlerts.FirstOrDefault(x => x is AndroidAlert);
-			push.Notification.IosAlert = (IosAlert)deviceAlerts.FirstOrDefault(x => x is IosAlert);
-			push.Notification.WindowsAlert = (WindowsAlert)deviceAlerts.FirstOrDefault(x => x is WindowsAlert);
-			push.Notification.WindowsPhoneAlert = (WindowsPhoneAlert)deviceAlerts.FirstOrDefault(x => x is WindowsPhoneAlert);
-			push.Notification.BlackberryAlert = (BlackberryAlert)deviceAlerts.FirstOrDefault(x => x is BlackberryAlert);
+            push.Notification.AndroidAlert = (AndroidAlert)deviceAlerts.FirstOrDefault(x => x is AndroidAlert);
+            push.Notification.IosAlert = (IosAlert)deviceAlerts.FirstOrDefault(x => x is IosAlert);
+            push.Notification.WindowsAlert = (WindowsAlert)deviceAlerts.FirstOrDefault(x => x is WindowsAlert);
+            push.Notification.WindowsPhoneAlert = (WindowsPhoneAlert)deviceAlerts.FirstOrDefault(x => x is WindowsPhoneAlert);
+            push.Notification.BlackberryAlert = (BlackberryAlert)deviceAlerts.FirstOrDefault(x => x is BlackberryAlert);
 
-			return push;
-		}
+            return push;
+        }
 
-	}
+
+        public BaseResponse RegisterDeviceToken(string deviceToken)
+        {
+            if (string.IsNullOrEmpty(deviceToken))
+                throw new ArgumentException("A device Token is Required", "deviceToken");
+
+            var deviceRequest = new DeviceTokenRequest(new DeviceToken() {Token = deviceToken});
+            var requestTask = deviceRequest.ExecuteAsync();
+
+            return requestTask.Result;
+        }
+    }
 }

--- a/src/UrbanAirSharp/UrbanAirSharpGateway.cs
+++ b/src/UrbanAirSharp/UrbanAirSharpGateway.cs
@@ -185,12 +185,34 @@ namespace UrbanAirSharp
         }
 
 
+        /// <summary>
+        /// Registers a device token only with the Urban Airship site, this can be used for new device tokens and for existing tokens.
+        /// The exitsing settings (badge, tags, alias, quiet times) will be overriden. If a token has become inactive reregistering it
+        /// will make it active again.
+        /// </summary>
+        /// <returns>Response from Urban Airship</returns>
         public BaseResponse RegisterDeviceToken(string deviceToken)
         {
             if (string.IsNullOrEmpty(deviceToken))
                 throw new ArgumentException("A device Token is Required", "deviceToken");
 
             var deviceRequest = new DeviceTokenRequest(new DeviceToken() {Token = deviceToken});
+            var requestTask = deviceRequest.ExecuteAsync();
+
+            return requestTask.Result;
+        }
+
+        /// <summary>
+        /// Registers a device token with extended properties with the Urban Airship site, this can be used for new device 
+        /// tokens and for existing tokens. If a token has become inactive reregistering it will make it active again. 
+        /// </summary>
+        /// <returns>Response from Urban Airship</returns>
+        public BaseResponse RegisterDeviceToken(DeviceToken deviceToken)
+        {
+            if (string.IsNullOrEmpty(deviceToken.Token))
+                throw new ArgumentException("A device Tokens Token field is Required", "deviceToken");
+
+            var deviceRequest = new DeviceTokenRequest(deviceToken);
             var requestTask = deviceRequest.ExecuteAsync();
 
             return requestTask.Result;


### PR DESCRIPTION
Liked your library and the way its written, but I needed a method of registering a Device Token so I could make sure device tokens are Active and change Inactive device tokens to active again when users reregister with the my application.

I just created a new PutRequest and DeviceTokenRequest classes, following your standards and a new DeviceToken dto class. I've also extended the Gateway class to have 2 methods which hide the calls to the DeviceTokenRequest.

Also would it be worth you creating a NuGet package and fleshing out more the API? There is nothing on NuGet last time I checked.
