### PR TITLE
Refactored to eliminate static ServiceModelConfig due to failing afte…

### DIFF
--- a/src/UrbanAirSharp/Request/Base/DeleteRequest.cs
+++ b/src/UrbanAirSharp/Request/Base/DeleteRequest.cs
@@ -8,8 +8,8 @@ namespace UrbanAirSharp.Request.Base
 {
 	public class DeleteRequest<TResponse> : BaseRequest<TResponse> where TResponse : BaseResponse, new()
 	{
-		public DeleteRequest()
-			: base(ServiceModelConfig.Host, ServiceModelConfig.HttpClient, ServiceModelConfig.SerializerSettings)
+		public DeleteRequest(ServiceModelConfig serviceModelConfig)
+			: base(serviceModelConfig.Host, serviceModelConfig.HttpClient, serviceModelConfig.SerializerSettings)
 		{
 			RequestMethod = HttpMethod.Delete;
 		}

--- a/src/UrbanAirSharp/Request/Base/GetRequest.cs
+++ b/src/UrbanAirSharp/Request/Base/GetRequest.cs
@@ -14,8 +14,8 @@ namespace UrbanAirSharp.Request.Base
 	/// </summary>
 	public class GetRequest<TResponse> : BaseRequest<TResponse> where TResponse : BaseResponse, new()
 	{
-		public GetRequest()
-			: base(ServiceModelConfig.Host, ServiceModelConfig.HttpClient, ServiceModelConfig.SerializerSettings)
+		public GetRequest(ServiceModelConfig serviceModelConfig)
+			: base(serviceModelConfig.Host, serviceModelConfig.HttpClient, serviceModelConfig.SerializerSettings)
 		{
 			RequestMethod = HttpMethod.Get;
 		}

--- a/src/UrbanAirSharp/Request/Base/PostRequest.cs
+++ b/src/UrbanAirSharp/Request/Base/PostRequest.cs
@@ -23,8 +23,8 @@ namespace UrbanAirSharp.Request.Base
 
 		protected TContent Content;
 		
-		public PostRequest(TContent content)
-			: base(ServiceModelConfig.Host, ServiceModelConfig.HttpClient, ServiceModelConfig.SerializerSettings)
+		public PostRequest(TContent content, ServiceModelConfig serviceModelConfig)
+			: base(serviceModelConfig.Host, serviceModelConfig.HttpClient, serviceModelConfig.SerializerSettings)
 		{
 			RequestMethod = HttpMethod.Post;
 			Content = content;
@@ -38,9 +38,10 @@ namespace UrbanAirSharp.Request.Base
 
 			Log.Debug("Payload - " + json);
 
-			var response = await HttpClient.PostAsync(Host + RequestUrl, new StringContent(json, Encoding, MediaType));
-
-			return await DeserializeResponseAsync(response);
+            using (var response = await HttpClient.PostAsync(Host + RequestUrl, new StringContent(json, Encoding, MediaType)))
+            { 
+                return await DeserializeResponseAsync(response);
+            }
 		}
 	}
 }

--- a/src/UrbanAirSharp/Request/Base/PutRequest.cs
+++ b/src/UrbanAirSharp/Request/Base/PutRequest.cs
@@ -14,8 +14,8 @@ namespace UrbanAirSharp.Request.Base
 
         protected TContent Content;
 
-		public PutRequest(TContent content)
-			: base(ServiceModelConfig.Host, ServiceModelConfig.HttpClient, ServiceModelConfig.SerializerSettings)
+		public PutRequest(TContent content, ServiceModelConfig serviceModelConfig)
+			: base(serviceModelConfig.Host, serviceModelConfig.HttpClient, serviceModelConfig.SerializerSettings)
         {
 			RequestMethod = HttpMethod.Put;
             Content = content;

--- a/src/UrbanAirSharp/Request/DeviceTokenRequest.cs
+++ b/src/UrbanAirSharp/Request/DeviceTokenRequest.cs
@@ -11,7 +11,7 @@ namespace UrbanAirSharp.Request
     /// <see cref="http://docs.urbanairship.com/reference/api/v3/registration.html"/>
 	public class DeviceTokenRequest : PutRequest<BaseResponse, DeviceToken>
     {
-        public DeviceTokenRequest(DeviceToken device) : base(device)
+        public DeviceTokenRequest(DeviceToken device, ServiceModelConfig serviceModelConfig) : base(device, serviceModelConfig)
         {
             if (string.IsNullOrEmpty(device.Token))
                 throw new ArgumentException("The device tokens Token field is required", "device");

--- a/src/UrbanAirSharp/Request/PushRequest.cs
+++ b/src/UrbanAirSharp/Request/PushRequest.cs
@@ -12,8 +12,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class PushRequest : PostRequest<PushResponse, Push>
 	{
-		public PushRequest(Push push)
-			: base(push)
+		public PushRequest(Push push, ServiceModelConfig serviceModelConfig)
+			: base(push, serviceModelConfig)
 		{
 			RequestUrl = "api/push/";
 		}

--- a/src/UrbanAirSharp/Request/PushValidateRequest.cs
+++ b/src/UrbanAirSharp/Request/PushValidateRequest.cs
@@ -11,8 +11,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class PushValidateRequest : PushRequest
 	{
-		public PushValidateRequest(Push push)
-			: base(push)
+		public PushValidateRequest(Push push, ServiceModelConfig serviceModelConfig)
+			: base(push, serviceModelConfig)
 		{
 			RequestUrl = "api/push/validate/";
 		}

--- a/src/UrbanAirSharp/Request/ScheduleCreateRequest.cs
+++ b/src/UrbanAirSharp/Request/ScheduleCreateRequest.cs
@@ -12,8 +12,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class ScheduleCreateRequest : PostRequest<ScheduleCreateResponse, Schedule>
 	{
-		public ScheduleCreateRequest(Schedule schedule)
-			: base(schedule)
+		public ScheduleCreateRequest(Schedule schedule, ServiceModelConfig serviceModelConfig)
+			: base(schedule, serviceModelConfig)
 		{
 			RequestUrl = "api/schedules/";
 		}

--- a/src/UrbanAirSharp/Request/ScheduleDeleteRequest.cs
+++ b/src/UrbanAirSharp/Request/ScheduleDeleteRequest.cs
@@ -11,7 +11,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class ScheduleDeleteRequest : DeleteRequest<BaseResponse>
 	{
-		public ScheduleDeleteRequest(Guid scheduleId)
+		public ScheduleDeleteRequest(Guid scheduleId, ServiceModelConfig serviceModelConfig)
+            : base(serviceModelConfig)
 		{
 			RequestUrl = "api/schedules/" + scheduleId + "/";
 		}

--- a/src/UrbanAirSharp/Request/ScheduleEditRequest.cs
+++ b/src/UrbanAirSharp/Request/ScheduleEditRequest.cs
@@ -12,8 +12,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class ScheduleEditRequest : PutRequest<ScheduleEditResponse, Schedule>
 	{
-		public ScheduleEditRequest(Guid scheduleId, Schedule schedule) 
-			: base (schedule)
+		public ScheduleEditRequest(Guid scheduleId, Schedule schedule, ServiceModelConfig serviceModelConfig) 
+			: base (schedule, serviceModelConfig)
 		{
 			RequestUrl = "api/schedules/" + scheduleId + "/";
 		}

--- a/src/UrbanAirSharp/Request/ScheduleGetRequest.cs
+++ b/src/UrbanAirSharp/Request/ScheduleGetRequest.cs
@@ -11,7 +11,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class ScheduleGetRequest : GetRequest<ScheduleGetResponse>
 	{
-		public ScheduleGetRequest(Guid scheduleId)
+		public ScheduleGetRequest(Guid scheduleId, ServiceModelConfig serviceModelConfig)
+            : base(serviceModelConfig)
 		{
 			RequestUrl = "api/schedules/" + scheduleId + "/";
 		}

--- a/src/UrbanAirSharp/Request/ScheduleListRequest.cs
+++ b/src/UrbanAirSharp/Request/ScheduleListRequest.cs
@@ -11,7 +11,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class ScheduleListRequest : GetRequest<ScheduleListResponse>
 	{
-		public ScheduleListRequest()
+		public ScheduleListRequest(ServiceModelConfig serviceModelConfig)
+            : base(serviceModelConfig)
 		{
 			RequestUrl = "api/schedules/";
 		}

--- a/src/UrbanAirSharp/Request/TagCreateRequest.cs
+++ b/src/UrbanAirSharp/Request/TagCreateRequest.cs
@@ -12,8 +12,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class TagCreateRequest : PutRequest<BaseResponse, Tag>
 	{
-		public TagCreateRequest(Tag tag)
-			: base(tag)
+		public TagCreateRequest(Tag tag, ServiceModelConfig serviceModelConfig)
+			: base(tag, serviceModelConfig)
 		{
 			RequestUrl = "api/tags/" + tag.TagName + "/";
 		}

--- a/src/UrbanAirSharp/Request/TagDeleteRequest.cs
+++ b/src/UrbanAirSharp/Request/TagDeleteRequest.cs
@@ -12,7 +12,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class TagDeleteRequest : DeleteRequest<BaseResponse>
 	{
-		public TagDeleteRequest(String tag)
+		public TagDeleteRequest(String tag, ServiceModelConfig serviceModelConfig)
+            :base(serviceModelConfig)
 		{
 			RequestUrl = "api/tags/" + tag + "/";
 		}

--- a/src/UrbanAirSharp/Request/TagListRequest.cs
+++ b/src/UrbanAirSharp/Request/TagListRequest.cs
@@ -11,7 +11,8 @@ namespace UrbanAirSharp.Request
 	/// </summary>
 	public class TagListRequest : GetRequest<TagListResponse>
 	{
-		public TagListRequest()
+		public TagListRequest(ServiceModelConfig serviceModelConfig)
+            : base(serviceModelConfig)
 		{
 			RequestUrl = "api/tags/";
 		}

--- a/src/UrbanAirSharp/ServiceModelConfig.cs
+++ b/src/UrbanAirSharp/ServiceModelConfig.cs
@@ -10,26 +10,31 @@ using Newtonsoft.Json.Converters;
 
 namespace UrbanAirSharp
 {
-	public static class ServiceModelConfig
+	public class ServiceModelConfig
 	{
-		public static readonly String Host = "https://go.urbanairship.com/";
-		public static readonly HttpClient HttpClient = new HttpClient();
-		public static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings();
+		public readonly String Host = "https://go.urbanairship.com/";
+		public readonly HttpClient HttpClient = new HttpClient();
+		public readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings();
 
-		public static void Create(String uaAppKey, String uaAppMAsterSecret)
-		{
-			var auth = String.Format("{0}:{1}", uaAppKey, uaAppMAsterSecret);
-			auth = Convert.ToBase64String(Encoding.ASCII.GetBytes(auth));
+	    public static ServiceModelConfig Create(String uaAppKey, String uaAppMAsterSecret)
+	    {
+	        return new ServiceModelConfig(uaAppKey, uaAppMAsterSecret);
+	    }
 
-			SerializerSettings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
+        public ServiceModelConfig(String uaAppKey, String uaAppMAsterSecret)
+        {
+            var auth = String.Format("{0}:{1}", uaAppKey, uaAppMAsterSecret);
+            auth = Convert.ToBase64String(Encoding.ASCII.GetBytes(auth));
+
+            HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", auth);
+            HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "application/vnd.urbanairship+json; version=3;");
+            //System.Net.ServicePointManager.Expect100Continue = false;
+            SerializerSettings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
 			SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
 			SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
 			SerializerSettings.DateParseHandling = DateParseHandling.DateTime;
 			SerializerSettings.DateFormatHandling = DateFormatHandling.IsoDateFormat;
 			SerializerSettings.DateFormatString = "yyyy-MM-ddTH:mm:ss";
-
-			HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", auth);
-			HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "application/vnd.urbanairship+json; version=3;");
 		}
 	}
 }

--- a/src/UrbanAirSharp/UrbanAirSharp.csproj
+++ b/src/UrbanAirSharp/UrbanAirSharp.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/UrbanAirSharp/UrbanAirSharpGateway.cs
+++ b/src/UrbanAirSharp/UrbanAirSharpGateway.cs
@@ -42,11 +42,13 @@ namespace UrbanAirSharp
 	public class UrbanAirSharpGateway
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof(UrbanAirSharpGateway));
+	    private readonly ServiceModelConfig serviceModelConfig;
 
-		public UrbanAirSharpGateway(String appKey, String appMasterSecret)
+
+        public UrbanAirSharpGateway(String appKey, String appMasterSecret)
 		{
 			XmlConfigurator.Configure();
-			ServiceModelConfig.Create(appKey, appMasterSecret);
+			serviceModelConfig = ServiceModelConfig.Create(appKey, appMasterSecret);
 		}
 
 		/// <summary>
@@ -63,7 +65,7 @@ namespace UrbanAirSharp
 		/// <returns></returns>
 		public PushResponse Push(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null, IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
 		{
-			return SendRequest(new PushRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience)));
+			return SendRequest(new PushRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience), serviceModelConfig));
 		}
 
 		/// <summary>
@@ -78,32 +80,32 @@ namespace UrbanAirSharp
 		public PushResponse Validate(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null,
 			IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)
 		{
-			return SendRequest(new PushValidateRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience)));
+			return SendRequest(new PushValidateRequest(CreatePush(alert, deviceTypes, deviceId, deviceAlerts, customAudience), serviceModelConfig));
 		}
 
 		public ScheduleCreateResponse CreateSchedule(Schedule schedule)
         {
-			return SendRequest(new ScheduleCreateRequest(schedule));
+			return SendRequest(new ScheduleCreateRequest(schedule, serviceModelConfig));
         }
 
 		public ScheduleEditResponse EditSchedule(Guid scheduleId, Schedule schedule)
         {
-			return SendRequest(new ScheduleEditRequest(scheduleId, schedule));
+			return SendRequest(new ScheduleEditRequest(scheduleId, schedule, serviceModelConfig));
         }
 
 		public BaseResponse DeleteSchedule(Guid scheduleId)
         {
-			return SendRequest(new ScheduleDeleteRequest(scheduleId));
+			return SendRequest(new ScheduleDeleteRequest(scheduleId, serviceModelConfig));
         }
 
         public ScheduleGetResponse GetSchedule(Guid scheduleId)
         {
-			return SendRequest(new ScheduleGetRequest(scheduleId));
+			return SendRequest(new ScheduleGetRequest(scheduleId, serviceModelConfig));
         }
 
         public ScheduleListResponse ListSchedules()
         {
-			return SendRequest(new ScheduleListRequest());
+			return SendRequest(new ScheduleListRequest(serviceModelConfig));
         }
 
 		/// <summary>
@@ -127,7 +129,7 @@ namespace UrbanAirSharp
 			if (string.IsNullOrEmpty(deviceToken.Token))
 				throw new ArgumentException("A device Tokens Token field is Required", "deviceToken");
 
-			return SendRequest(new DeviceTokenRequest(deviceToken));
+			return SendRequest(new DeviceTokenRequest(deviceToken, serviceModelConfig));
 		}
 
 		public BaseResponse CreateTag(Tag tag)
@@ -135,7 +137,7 @@ namespace UrbanAirSharp
 			if (string.IsNullOrEmpty(tag.TagName))
 				throw new ArgumentException("A tag name is Required", "tag.TagName");
 
-			return SendRequest(new TagCreateRequest(tag));
+			return SendRequest(new TagCreateRequest(tag, serviceModelConfig));
 		}
 
 		public BaseResponse DeleteTag(string tag)
@@ -143,12 +145,12 @@ namespace UrbanAirSharp
 			if (string.IsNullOrEmpty(tag))
 				throw new ArgumentException("A tag is Required", "tag");
 
-			return SendRequest(new TagDeleteRequest(tag));
+			return SendRequest(new TagDeleteRequest(tag, serviceModelConfig));
 		}
 
 		public TagListResponse ListTags()
 		{
-			return SendRequest(new TagListRequest());
+			return SendRequest(new TagListRequest(serviceModelConfig));
 		}
 
 		public static Push CreatePush(String alert, IList<DeviceType> deviceTypes = null, String deviceId = null, IList<BaseAlert> deviceAlerts = null, Audience customAudience = null)


### PR DESCRIPTION
The UrbanAirSharp library fails after 160 requests if your program creates a new instance of the UrbanAirshipGateway for each request. Due to our multi-tenant application, this is a requirement. The reason it fails is due to the static ServiceModelConfig class which contains a static reference to the HttpClient class. I have refactored the code to change ServiceModelConfig from a static class to an instance class which eliminates this issue.